### PR TITLE
add support for the is_active query param on the project_budget report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes between versions
 
+## Unreleased
+
+ * add support for the `is_active` query param on the `/reports/project_budget` endpoint - see jolicode/harvest-openapi-generator#14
+
 ## 4.1.0 (2020-08-21)
 
  * use Jane 6 Authentication plugins

--- a/Resources/harvest-openapi.yaml
+++ b/Resources/harvest-openapi.yaml
@@ -3343,6 +3343,12 @@ paths:
           required: false
           in: query
           type: integer
+        -
+          name: is_active
+          description: 'Pass true to only return active projects and false to return inactive projects.'
+          required: false
+          in: query
+          type: boolean
       responses:
         200:
           description: 'Project Budget Report'
@@ -5108,7 +5114,7 @@ definitions:
         description: 'Whether the company is active or archived.'
       week_start_day:
         type: string
-        description: 'The week day used as the start of the week. Returns one of: Saturday, Sunday, or Monday.'
+        description: 'The weekday used as the start of the week. Returns one of: Saturday, Sunday, or Monday.'
       wants_timestamp_timers:
         type: boolean
         description: 'Whether time is tracked via duration or start and end times.'

--- a/generated/Client.php
+++ b/generated/Client.php
@@ -1006,6 +1006,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Client
      * @param array $queryParameters {
      *     @var int $page The page number to use in pagination. For instance, if you make a list request and receive 100 records, your subsequent call can include page=2 to retrieve the next page of the list. (Default: 1)
      *     @var int $per_page The number of records to return per page. Can range between 1 and 1000.  (Default: 1000)
+     *     @var bool $is_active Pass true to only return active projects and false to return inactive projects.
      * }
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *

--- a/generated/Endpoint/ProjectBudgetReport.php
+++ b/generated/Endpoint/ProjectBudgetReport.php
@@ -10,6 +10,7 @@ class ProjectBudgetReport extends \Jane\OpenApiRuntime\Client\BaseEndpoint imple
      * @param array $queryParameters {
      *     @var int $page The page number to use in pagination. For instance, if you make a list request and receive 100 records, your subsequent call can include page=2 to retrieve the next page of the list. (Default: 1)
      *     @var int $per_page The number of records to return per page. Can range between 1 and 1000.  (Default: 1000)
+     *     @var bool $is_active Pass true to only return active projects and false to return inactive projects.
      * }
      */
     public function __construct(array $queryParameters = array())
@@ -32,11 +33,13 @@ class ProjectBudgetReport extends \Jane\OpenApiRuntime\Client\BaseEndpoint imple
     protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
-        $optionsResolver->setDefined(array('page', 'per_page'));
+        $optionsResolver->setDefined(array('page', 'per_page', 'is_active'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
         $optionsResolver->setAllowedTypes('page', array('int'));
         $optionsResolver->setAllowedTypes('per_page', array('int'));
+        $optionsResolver->setAllowedTypes('is_active', array('bool'));
+        $optionsResolver->setNormalizer('is_active', \Closure::fromCallable(array(new \JoliCode\Harvest\BooleanCustomQueryResolver(), '__invoke')));
         return $optionsResolver;
     }
     /**

--- a/generated/Model/Company.php
+++ b/generated/Model/Company.php
@@ -29,7 +29,7 @@ class Company
      */
     protected $isActive;
     /**
-     * The week day used as the start of the week. Returns one of: Saturday, Sunday, or Monday.
+     * The weekday used as the start of the week. Returns one of: Saturday, Sunday, or Monday.
      *
      * @var string|null
      */
@@ -191,7 +191,7 @@ class Company
         return $this;
     }
     /**
-     * The week day used as the start of the week. Returns one of: Saturday, Sunday, or Monday.
+     * The weekday used as the start of the week. Returns one of: Saturday, Sunday, or Monday.
      *
      * @return string|null
      */
@@ -200,7 +200,7 @@ class Company
         return $this->weekStartDay;
     }
     /**
-     * The week day used as the start of the week. Returns one of: Saturday, Sunday, or Monday.
+     * The weekday used as the start of the week. Returns one of: Saturday, Sunday, or Monday.
      *
      * @param string|null $weekStartDay
      *


### PR DESCRIPTION
add support for the `is_active` query param on the `/reports/project_budget` endpoint - see jolicode/harvest-openapi-generator#14